### PR TITLE
Add element search functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,10 @@ go 1.18
 require (
 	github.com/charmbracelet/bubbletea v0.20.0
 	github.com/charmbracelet/lipgloss v0.5.0
+	golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75
 )
+
+require github.com/atotto/clipboard v0.1.4 // indirect
 
 require (
 	github.com/charmbracelet/bubbles v0.10.3

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/charmbracelet/bubbles v0.10.3 h1:fKarbRaObLn/DCsZO4Y3vKCwRUzynQD9L+gGev1E/ho=
 github.com/charmbracelet/bubbles v0.10.3/go.mod h1:jOA+DUF1rjZm7gZHcNyIVW+YrBPALKfpGVdJu8UiJsA=
@@ -36,6 +37,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
+golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75 h1:x03zeu7B2B11ySp+daztnwM5oBJ/8wGUSqrwcw9L0RA=
+golang.org/x/exp v0.0.0-20220713135740-79cabaa25d75/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/src/elements/import.go
+++ b/src/elements/import.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 	"periodic-table/ui/element"
-	"periodic-table/ui/table"
+	"periodic-table/ui/grid"
 )
 
 var (
@@ -18,7 +18,7 @@ var (
 	}
 )
 
-func ReadElements() []table.Cell {
+func ReadElements() []grid.Cell {
 	// open file
 	f, err := os.Open("data/elements.csv")
 	if err != nil {
@@ -44,10 +44,10 @@ func ReadElements() []table.Cell {
 	return createElements(data)
 }
 
-func createElements(data [][]string) []table.Cell {
-	var elements []table.Cell
+func createElements(data [][]string) []grid.Cell {
+	var elements []grid.Cell
 	var count int
-	var lastGroups []table.Cell
+	var lastGroups []grid.Cell
 	for i, line := range data {
 		if skipLines := emptyEntryRange[count]; skipLines != 0 {
 			for j := count; j < skipLines; j++ {

--- a/ui/element/element.go
+++ b/ui/element/element.go
@@ -2,7 +2,7 @@ package element
 
 import (
 	"fmt"
-	"periodic-table/ui/table"
+	"periodic-table/ui/grid"
 
 	"github.com/charmbracelet/lipgloss"
 )
@@ -87,6 +87,14 @@ func (c *Cell) GetView() string {
 	return text
 }
 
+func (c *Cell) GetUnselectedStyle() lipgloss.Style {
+	return c.unSelectedStyle
+}
+
+func (c *Cell) GetSelectedStyle() lipgloss.Style {
+	return c.selectedStyle
+}
+
 func (c *Cell) SetStyle(selectedStyle lipgloss.Style, unSelectedStyle lipgloss.Style) {
 	c.selectedStyle = selectedStyle
 	c.unSelectedStyle = unSelectedStyle
@@ -106,7 +114,7 @@ func (c *Cell) IsPaddingCell() bool {
 	return c.isPaddingCell
 }
 
-func CreateElement(data Data, isPaddingCell bool) table.Cell {
+func CreateElement(data Data, isPaddingCell bool) grid.Cell {
 	unSelectedStyle := style.Copy().BorderForeground(TypeColors[data.Type])
 	selectedStyle := unSelectedStyle.Copy().Background(TypeColors[data.Type])
 

--- a/ui/grid/cell.go
+++ b/ui/grid/cell.go
@@ -1,4 +1,4 @@
-package table
+package grid
 
 import "github.com/charmbracelet/lipgloss"
 
@@ -7,6 +7,8 @@ type Cell interface {
 	GetView() string
 	SetStyle(selectedStyle lipgloss.Style, unSelectedStyle lipgloss.Style)
 	SetSelected(isSelected bool)
+	GetUnselectedStyle() lipgloss.Style
+	GetSelectedStyle() lipgloss.Style
 	GetSearchString() string
 	GetData() interface{}
 	IsPaddingCell() bool

--- a/ui/grid/grid_test.go
+++ b/ui/grid/grid_test.go
@@ -1,9 +1,49 @@
-package table
+package grid
 
 import (
-	"periodic-table/ui/element"
+	"github.com/charmbracelet/lipgloss"
 	"testing"
 )
+
+type mockCell struct {
+	SelectedStyle   lipgloss.Style
+	UnSelectedStyle lipgloss.Style
+	SearchString    string
+	IsSelected      bool
+	IsPaddingCell   bool
+	View            string
+}
+
+func (c *mockCell) GetSearchString() string {
+	return c.searchString
+}
+
+func (c *mockCell) GetData() interface{} {
+	return "no data"
+}
+
+func (c *mockCell) GetView() string {
+	return c.View
+}
+
+func (c *mockCell) GetUnselectedStyle() lipgloss.Style {
+	return c.unSelectedStyle
+}
+
+func (c *mockCell) SetStyle(selectedStyle lipgloss.Style, unSelectedStyle lipgloss.Style) {
+	c.selectedStyle = selectedStyle
+	c.unSelectedStyle = unSelectedStyle
+}
+
+func (c *mockCell) SetSelected(isSelected bool) {
+	c.isSelected = isSelected
+}
+
+func styleText(atomicNumber string, symbol string) string {
+	text := lipgloss.Place(width, height, 1, 1, symbol)
+	text = lipgloss.JoinVertical(0, lipgloss.Place(0, 0, 0, 0, atomicNumber), text)
+	return text
+}
 
 func TestModel_SetGrid(t *testing.T) {
 	type args struct {
@@ -85,7 +125,7 @@ func TestModel_SetGrid(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var elements []element.Model
+			var cells []mockCell
 			for i := 0; i < tt.args.numberOfElements; i++ {
 				elements = append(elements, element.Model{})
 			}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -3,7 +3,7 @@ package ui
 import (
 	"periodic-table/src/elements"
 	"periodic-table/ui/element"
-	"periodic-table/ui/table"
+	"periodic-table/ui/grid"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -15,7 +15,7 @@ const (
 )
 
 type Model struct {
-	table table.Model
+	table grid.Model
 	state int
 }
 
@@ -24,21 +24,9 @@ func (m Model) Init() tea.Cmd {
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	var cmds []tea.Cmd
 	var cmd tea.Cmd
-	switch m.state {
-	case tableView:
-		switch msg := msg.(type) {
-		case tea.KeyMsg:
-			if msg.String() == "enter" {
-				m.state = elementView
-			}
-		}
-		m.table, cmd = m.table.Update(msg)
-		cmds = append(cmds, cmd)
-	}
-
-	return m, tea.Batch(cmds...)
+	m.table, cmd = m.table.Update(msg)
+	return m, cmd
 }
 
 func elementInfoView(elem element.Data) string {
@@ -69,6 +57,6 @@ func (m Model) View() string {
 func CreateModel() (tea.Model, error) {
 	elements := elements.ReadElements()
 
-	table, err := table.CreateModel(elements, table.GridSettings{Rows: 10, Columns: 18})
+	table, err := grid.CreateModel(elements, grid.GridSettings{Rows: 10, Columns: 18})
 	return Model{table: table}, err
 }


### PR DESCRIPTION
This PR adds the ability to search for elements in the periodic
table using the '/' key.

This commit also adds minor changes:
- Renamed 'table' package to 'grid'.
- Get and set cell styles.
- Control movement with VIM bindings.